### PR TITLE
Upadates HQ URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Headquarters-node
 
 [![Build Status](https://semaphoreapp.com/api/v1/projects/f70c710e-d453-4c9e-bdf2-665718bef386/358218/shields_badge.svg)](https://semaphoreapp.com/groupbuddies/headquarters-node)
 
-Node wrapper for the [headquarters API](https://github.com/groupbuddies/headquarters).
+Node wrapper for the [headquarters API](https://github.com/subvisual/headquarters).
 
 
 
@@ -24,7 +24,7 @@ Before making request you need to authorization your application. At the moment 
 
 This flow allows you to authorize each person, retrieving an access token to make requests in the name of the user.
 
-Instantiate headquarters-node with the `clientID` `clientSecret` and `callbackURL` (you need to have an application registered on the [headquarters](https://hq.groupbuddies.com/admin) first):
+Instantiate headquarters-node with the `clientID` `clientSecret` and `callbackURL` (you need to have an application registered on the [headquarters](https://hq.subvisual.co/admin) first):
 
 ```js
 var Headquarters = require('headquarters-node');
@@ -32,7 +32,7 @@ var Headquarters = require('headquarters-node');
 var credentials = {
   clientID: "dummy_client_id",
   clientSecret: "dummy_client_secret",
-  callbackURL: "https://example.groupbuddies.com/callback"
+  callbackURL: "https://example.subvisual.co/callback"
   type: "authorizationCode"
 };
 
@@ -60,7 +60,7 @@ This method returns a promise when finished. After that you can start making req
 This flow allows your application to make requests without user authorization. It works as if your application is an user by himself. This can be used for requests that don't need to be associated to a user.
 
 
-Instantiate headquarters-node with `clientID` and `clientSecret` (you need to have an application registered on the [headquarters](https://hq.groupbuddies.com/admin) first):
+Instantiate headquarters-node with `clientID` and `clientSecret` (you need to have an application registered on the [headquarters](https://hq.subvisual.co/admin) first):
 
 ```js
 var Headquarters = require('headquarters-node');
@@ -99,7 +99,7 @@ To search members of the team you might use the `search`
 method:
 
 ```js
-return headquarters.member.search('gabriel@groupbuddies.com');
+return headquarters.member.search('gabriel@subvisual.com');
 ```
 
 This returns a promise that resolves an array of members.
@@ -126,7 +126,7 @@ To send emails you can use the following method:
 
 ```js
 var params = {
-  to: 'gabriel@groupbuddies.com',
+  to: 'gabriel@subvisual.com',
   subject: 'Houston, we have a problem',
   body: 'Yes Mr. President.'
 };
@@ -155,7 +155,7 @@ headquarters.github.pullrequests(query);
 ```
 
 This method is a proxy to the Github api, it supports the same query parameters.
-The search for pull requests is limited to the user **groupbuddies**.
+The search for pull requests is limited to the user **subvisual**.
 It return a promise that resolves with the json response from the Github API, see [here](https://developer.github.com/v3/pulls/#list-pull-requests) for more information.
 
 
@@ -168,7 +168,7 @@ Contributing
 To contribute you need to setup the development environment. First clone the project.
 
 ```
-git clone git@github.com:groupbuddies/headquarters-node.git
+git clone git@github.com:subvisual/headquarters-node.git
 ```
 
 Then install the development dependencies.

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var APIBaseURL = "https://hq.groupbuddies.com";
+var APIBaseURL = "https://hq.subvisual.co";
 var APIMembersPath = "/members";
 var APIEmailPath = "/emails";
 var APITokenPath = "/oauth/authorize";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-let APIBaseURL = 'https://hq.groupbuddies.com';
+let APIBaseURL = 'https://hq.subvisual.co';
 let APIMembersPath = '/members';
 let APIEmailPath = '/emails';
 let APITokenPath =  '/oauth/authorize';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headquarters-node",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Node wrapper for the headquarters API for Group Buddies",
   "homepage": "https://github.com/groupbuddies/headquarters-node",
   "main": "dist/headquarters-node.js",


### PR DESCRIPTION
This updates HQ URL to use hq.subvisual.co instead of hq.groupbuddies.com.
